### PR TITLE
Fixed memory usage by using reference instead of values for scan function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inclusivelint",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "description": "Core library for inclusivelint",
   "main": "./dist/pkg-index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inclusivelint",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Core library for inclusivelint",
   "main": "./dist/pkg-index.js",
   "bin": {


### PR DESCRIPTION
We are now avoiding passing the file content to any function, so memory consumption is reduced. This is specially important when iterating through files.

Reason: Javascript is pass-by-value for values, but passes references when working with objects. In the current version, the fileContent string will always be copied when 'scan' is called, producing higher memory consumption. With this change, we are now passing an object which contains the file content in a field, thus avoiding unnecessary copies of the entire file.