### PR TITLE
Adding `master` by itself

### DIFF
--- a/src/wordsTable.md
+++ b/src/wordsTable.md
@@ -293,6 +293,7 @@
 | `housewives` | [basic](#basic) | `housewives` | `homemakers`, `homeworkers` |
 | `motherly` | [basic](#basic) | `motherly` | `loving`, `warm`, `nurturing` |
 | `manpower` | [basic](#basic) | `manpower` | `human resources`, `workforce`, `personnel`, `staff`, `labor`, `labor force`, `staffing`, `combat personnel` |
+| `master` | [basic](#basic) | `master` | `primary`, `main`, `default` |
 | `master of ceremonies` | [basic](#basic) | `master of ceremonies` | `emcee`, `moderator`, `convenor` |
 | `masterful` | [basic](#basic) | `masterful` | `skilled`, `authoritative`, `commanding` |
 | `mastermind` | [basic](#basic) | `mastermind` | `genius`, `creator`, `instigator`, `oversee`, `launch`, `originate` |


### PR DESCRIPTION
The list contains master-slave and various versions of master such as master of ceremonies but it does not include master by itself.  According to https://inclusivenaming.org/language/word-list/, it should.

Signed-off-by: John Bent <john.bent@seagate.com>